### PR TITLE
Add more features, fix bugs and issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@ Migrates Users, Channels and all the conversations from a Slack export to Matrix
 
 Warning: It's not recommended to use anything but a fresh/empty Synapse instance for migration
 
+However, you can configure it to import the Slack workspace to an empty federated server
+and use that to effectively migrate rooms to an existing Matrix server via federation.
+See 'Federated setup (import to an existing Matrix server)' below.
+
 ## Prerequisites
 1. Install Python 3.7 with pip
 2. Set up a Synapse Homeserver
@@ -21,6 +25,28 @@ Notes:
 - Make sure the migration script can access the `/_matrix/client` api and the `/_synapse` admin api
 - Other Homeserver implementations may not support timestamped massaging, see https://matrix.org/docs/spec/application_service/r0.1.0#timestamp-massaging
 - You may have to increase your homserver rate limits
+
+## Federated setup (import to an existing Matrix server)
+
+The idea is to migrate Slack to a fresh/empty Synapse instance, that is federated with your existing Matrix homeserver.
+All imported Slack users will be kicked after the migration is done, leaving only the admin user in the migrated rooms.
+Invite any users from your existing Matrix homeserver to the rooms manually using the admin user.
+
+You will need the following configuration:
+
+```yaml
+# Set to 'True' to invite all users to all rooms
+invite-all: True
+# Set to 'True' to invite the admin user to all rooms
+create-as-admin: True
+# Set to 'True' to kick all imported users from imported rooms
+kick-imported-users: True
+# Set to 'True' to allow rooms to be joined from other homeservers
+federate-rooms: True
+# Append room and displayname suffixes
+room-suffix: " (slack import)"
+name-suffix: " (slack import)"
+```
 
 ## Running the migration
 1. Run `pip3 install -r required.txt`

--- a/README.md
+++ b/README.md
@@ -57,4 +57,5 @@ name-suffix: " (slack import)"
 ## Cleanup
 1. Remove the Application Service from your `homeserver.yaml`
 2. Delete the `migration_service.yaml`
-3. Restart Synapse
+3. Reset any increased rate limits
+4. Restart Synapse

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ Warning: It's not recommended to use anything but a fresh/empty Synapse instance
 
 ## Prerequisites
 1. Install Python 3.7 with pip
-2. Set up a Synapse Homeserver (other Homeserver implementations may not support timestamped massaging, see https://matrix.org/docs/spec/application_service/r0.1.0#timestamp-massaging)
+2. Set up a Synapse Homeserver
+  - other Homeserver implementations may not support timestamped massaging, see https://matrix.org/docs/spec/application_service/r0.1.0#timestamp-massaging
+  - requires access to `/_synapse` admin api
 3. Create an admin user on the Homeserver (make sure the username of the admin user does not match any existing slack user id)
 4. Copy `migration_service.yaml` to somewhere reachable by your Homeserver
 5. Replace the `as_token` and `hs_token` in the `migration_service.yaml` with a random string

--- a/README.md
+++ b/README.md
@@ -6,17 +6,24 @@ Warning: It's not recommended to use anything but a fresh/empty Synapse instance
 ## Prerequisites
 1. Install Python 3.7 with pip
 2. Set up a Synapse Homeserver
-  - other Homeserver implementations may not support timestamped massaging, see https://matrix.org/docs/spec/application_service/r0.1.0#timestamp-massaging
-  - requires access to `/_synapse` admin api
 3. Create an admin user on the Homeserver (make sure the username of the admin user does not match any existing slack user id)
 4. Copy `migration_service.yaml` to somewhere reachable by your Homeserver
 5. Replace the `as_token` and `hs_token` in the `migration_service.yaml` with a random string
-6. Add the Application Service to your `homeserver.yaml`:
+6. Add the Application Service to your `homeserver.yaml` and disable the registration rate limit:
 ```
 app_service_config_files:
   - /<path to the yaml file>/migration_service.yaml
+
+rc_registration:
+  per_second: 0
+  burst_count: 0
 ```
 7. Restart Synapse
+
+Notes:
+
+- Make sure the migration script can access the `/_matrix/client` api and the `/_synapse` admin api
+- Other Homeserver implementations may not support timestamped massaging, see https://matrix.org/docs/spec/application_service/r0.1.0#timestamp-massaging
 
 ## Running the migration
 1. Run `pip3 install -r required.txt`

--- a/README.md
+++ b/README.md
@@ -9,14 +9,10 @@ Warning: It's not recommended to use anything but a fresh/empty Synapse instance
 3. Create an admin user on the Homeserver (make sure the username of the admin user does not match any existing slack user id)
 4. Copy `migration_service.yaml` to somewhere reachable by your Homeserver
 5. Replace the `as_token` and `hs_token` in the `migration_service.yaml` with a random string
-6. Add the Application Service to your `homeserver.yaml` and disable the registration rate limit:
+6. Add the Application Service to your `homeserver.yaml`:
 ```
 app_service_config_files:
   - /<path to the yaml file>/migration_service.yaml
-
-rc_registration:
-  per_second: 0
-  burst_count: 0
 ```
 7. Restart Synapse
 
@@ -24,6 +20,7 @@ Notes:
 
 - Make sure the migration script can access the `/_matrix/client` api and the `/_synapse` admin api
 - Other Homeserver implementations may not support timestamped massaging, see https://matrix.org/docs/spec/application_service/r0.1.0#timestamp-massaging
+- You may have to increase your homserver rate limits
 
 ## Running the migration
 1. Run `pip3 install -r required.txt`

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -6,8 +6,6 @@ domain: example.org
 as_token: very-secret
 # Don't download files from Slack and upload them to Matrix
 skip-files: False
-# Slack token?
-slack_token: someslacktoken
 # Path to the Slack Backup relative to the current directory or absolute
 zipfile: ./Slack_Export.zip
 # Set to 'True' to perform a test without making changes to the homeserver

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -18,6 +18,8 @@ invite-all: False
 create-as-admin: False
 # Set to 'True' to kick all imported users from imported rooms
 kick-imported-users: False
+# Import public channels as private rooms
+import-as-private: False
 # Set to 'True' to allow rooms to be joined from other homeservers
 federate-rooms: False
 # Reply thread messages to previous thread message instead of parent message

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -12,5 +12,7 @@ zipfile: ./Slack_Export.zip
 dry-run: False
 # Set to 'False' if archived Channels from Slack should be migrated (and accessible in Matrix)
 skip-archived: True
-# Invite all users to all rooms
+# Set to 'True' to invite all users to all rooms
 invite-all: False
+# Set to 'True' to allow rooms to be joined from other homeservers
+federate-rooms: False

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -14,5 +14,10 @@ dry-run: False
 skip-archived: True
 # Set to 'True' to invite all users to all rooms
 invite-all: False
+# Set to 'True' to invite the admin user to all rooms
+create-as-admin: False
 # Set to 'True' to allow rooms to be joined from other homeservers
 federate-rooms: False
+# Append room and displayname suffixes
+room-suffix: ""
+name-suffix: ""

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -1,9 +1,13 @@
 # URL of your Matrix Homeserver Instance
 homeserver: https://example.org
+# Homeserver domain (domain part of the mxid)
+domain: example.org
 # Application Service Token from the matrix Homeserver
 as_token: very-secret
 # Don't download files from Slack and upload them to Matrix
 skip-files: False
+# Slack token?
+slack_token: someslacktoken
 # Path to the Slack Backup relative to the current directory or absolute
 zipfile: ./Slack_Export.zip
 # Set to 'True' to perform a test without making changes to the homeserver

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -16,6 +16,8 @@ skip-archived: True
 invite-all: False
 # Set to 'True' to invite the admin user to all rooms
 create-as-admin: False
+# Set to 'True' to kick all imported users from imported rooms
+kick-imported-users: False
 # Set to 'True' to allow rooms to be joined from other homeservers
 federate-rooms: False
 # Append room and displayname suffixes

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -20,6 +20,8 @@ create-as-admin: False
 kick-imported-users: False
 # Set to 'True' to allow rooms to be joined from other homeservers
 federate-rooms: False
+# Reply thread messages to previous thread message instead of parent message
+threads-reply-to-previous: True
 # Append room and displayname suffixes
 room-suffix: ""
 name-suffix: ""

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -12,3 +12,5 @@ zipfile: ./Slack_Export.zip
 dry-run: False
 # Set to 'False' if archived Channels from Slack should be migrated (and accessible in Matrix)
 skip-archived: True
+# Invite all users to all rooms
+invite-all: False

--- a/files.py
+++ b/files.py
@@ -16,7 +16,7 @@
 import requests
 import slackdown
 from utils import send_event
-from pyemojify import emojify
+from emoji import emojize
 
 '''
  * Converts a slack image attachment to a matrix image event.
@@ -290,11 +290,11 @@ def process_file(file, roomId, userId, body, txnId, config):
         #   so we just send a separate `m.image` and `m.text` message
         # See https://github.com/matrix-org/matrix-doc/issues/906
         if body:
-            body = emojify(body)
+            body = emojize(body, use_aliases=True)
             messageContent = {
                 "body": body,
                 "format": "org.matrix.custom.html",
-                "formatted_body": emojify(slackdown.render(body)),
+                "formatted_body": emojize(slackdown.render(body), use_aliases=True),
                 "msgtype": "m.text",
             }
 

--- a/files.py
+++ b/files.py
@@ -229,7 +229,9 @@ def process_snippet(file, roomId, userId, body, txnId, config, ts):
     # send message to room
     res = send_event(config, messageContent, roomId, userId, "m.room.message", txnId, ts)
     if res == False:
-        print("ERROR while sending snippet to room '" + roomId)
+        print("Could not send snippet to room '" + roomId + ", trying to send as file...")
+        txnId = process_upload(file, roomId, userId, body, txnId, config, ts)
+        return txnId
 
     return txnId
 
@@ -239,7 +241,7 @@ def process_upload(file, roomId, userId, body, txnId, config, ts):
             link = file["permalink_public"]
         else:
             link = file["url_private"]
-        print("File too large, sending as a link");
+        print("WARNING: File too large, sending as a link: " + link);
         messageContent = {
             "body": link + '(' + file["name"] + ')',
             "format": "org.matrix.custom.html",

--- a/files.py
+++ b/files.py
@@ -200,6 +200,8 @@ def process_file(file, roomId, userId, body, txnId, config):
         # we have no url to process the file
         return txnId
 
+    ts = str(file["timestamp"]) + "000"
+
     if file["mode"] == "snippet":
         htmlString = ""
         res = requests.get(file["url_private"])
@@ -232,10 +234,8 @@ def process_file(file, roomId, userId, body, txnId, config):
             "msgtype": "m.text",
         }
 
-        # TODO handle "event too large" exception, send as file
-
         # send message to room
-        res = send_event(config, messageContent, roomId, userId, "m.room.message", txnId, file["timestamp"])
+        res = send_event(config, messageContent, roomId, userId, "m.room.message", txnId, ts)
         if res == False:
             print("ERROR while sending snippet to room '" + roomId)
 
@@ -252,7 +252,7 @@ def process_file(file, roomId, userId, body, txnId, config):
                 "formatted_body": '<a href="' + link + '">' + file["name"] + '</a>',
                 "msgtype": "m.text",
             }
-            res = send_event(config, messageContent, roomId, userId, "m.room.message", txnId, file["timestamp"])
+            res = send_event(config, messageContent, roomId, userId, "m.room.message", txnId, ts)
             if res == False:
                 print("ERROR while sending file link to room '" + roomId)
 
@@ -282,7 +282,7 @@ def process_file(file, roomId, userId, body, txnId, config):
 
         messageContent = slackFileToMatrixMessage(file, fileContentUri, thumbnailContentUri)
 
-        res = send_event(config, messageContent, roomId, userId, "m.room.message", txnId, file["timestamp"])
+        res = send_event(config, messageContent, roomId, userId, "m.room.message", txnId, ts)
         if res == False:
             print("ERROR while sending file to room '" + roomId)
 
@@ -300,7 +300,7 @@ def process_file(file, roomId, userId, body, txnId, config):
                 "msgtype": "m.text",
             }
 
-            res = send_event(config, messageContent, roomId, userId, "m.room.message", txnId, file["timestamp"])
+            res = send_event(config, messageContent, roomId, userId, "m.room.message", txnId, ts)
             if res == False:
                 print("ERROR while sending file link to room '" + roomId)
 

--- a/files.py
+++ b/files.py
@@ -232,6 +232,8 @@ def process_file(file, roomId, userId, body, txnId, config):
             "msgtype": "m.text",
         }
 
+        # TODO handle "event too large" exception, send as file
+
         # send message to room
         res = send_event(config, messageContent, roomId, userId, "m.room.message", txnId, file["timestamp"])
         if res == False:

--- a/files.py
+++ b/files.py
@@ -291,18 +291,22 @@ def process_file(file, roomId, userId, body, txnId, config):
         # TODO: Currently Matrix lacks a way to upload a "captioned image",
         #   so we just send a separate `m.image` and `m.text` message
         # See https://github.com/matrix-org/matrix-doc/issues/906
-        if body:
-            body = emojize(body, use_aliases=True)
-            messageContent = {
-                "body": body,
-                "format": "org.matrix.custom.html",
-                "formatted_body": emojize(slackdown.render(body), use_aliases=True),
-                "msgtype": "m.text",
-            }
+        #
+        # TODO: The caption (message["text"]) will be sent anyway later after the return
+        #       This would create duplicated messages.
+        #
+        #if body:
+        #    body = emojize(body, use_aliases=True)
+        #    messageContent = {
+        #        "body": body,
+        #        "format": "org.matrix.custom.html",
+        #        "formatted_body": emojize(slackdown.render(body), use_aliases=True),
+        #        "msgtype": "m.text",
+        #    }
 
-            res = send_event(config, messageContent, roomId, userId, "m.room.message", txnId, ts)
-            if res == False:
-                print("ERROR while sending file link to room '" + roomId)
+        #    res = send_event(config, messageContent, roomId, userId, "m.room.message", txnId, ts)
+        #    if res == False:
+        #        print("ERROR while sending file link to room '" + roomId)
 
     txnId = txnId + 1
     return txnId

--- a/files.py
+++ b/files.py
@@ -15,7 +15,7 @@
 
 import requests
 import slackdown
-from utils import send_event
+from utils import send_event, print
 from emoji import emojize
 
 '''

--- a/files.py
+++ b/files.py
@@ -222,6 +222,7 @@ def process_file(file, roomId, userId, body, txnId, config):
         else:
             htmlCode = "<pre><code>"
 
+        htmlCode += htmlString
         htmlCode += "</code></pre>"
 
         messageContent = {

--- a/migrate.py
+++ b/migrate.py
@@ -27,7 +27,7 @@ import getpass
 import string
 import secrets
 import time
-from pyemojify import emojify
+from emoji import emojize
 import slackdown
 import re
 from files import process_attachments, process_files
@@ -586,17 +586,13 @@ def parse_and_send_message(config, message, matrix_room, txnId, is_later):
             slack_event_id = replyLUT[message["user"]+message["ts"]]
             matrix_event_id = eventLUT[slack_event_id]
 
-
         # TODO pinned / stared items?
 
-
+        # replace emojis
+        body = emojize(body, use_aliases=True)
 
         # TODO some URLs with special characters (e.g. _ ) are parsed wrong
         formatted_body = slackdown.render(body)
-
-        # replace emojis
-        formatted_body = emojify(formatted_body)
-        body = emojify(body)
 
         if not is_reply:
             content = {
@@ -645,7 +641,7 @@ def parse_and_send_message(config, message, matrix_room, txnId, is_later):
                 for reaction in message["reactions"]:
                     for user in reaction["users"]:
                         #print("Send reaction in room " + roomId)
-                        send_reaction(config, roomId, eventId, emojify(reaction["name"]), userLUT[user], txnId)
+                        send_reaction(config, roomId, eventId, emojize(reaction["name"], use_aliases=True), userLUT[user], txnId)
                         txnId = txnId + 1
 
     else:

--- a/migrate.py
+++ b/migrate.py
@@ -216,7 +216,7 @@ def register_user(
     print("Creating user @%s:%s" % (user,config_yaml['domain']))
     r = requests.put(url, json=data, headers=headers, verify=False)
 
-    if r.status_code != 200:
+    if r.status_code != 200 and r.status_code != 201:
         print("ERROR! Received %d %s" % (r.status_code, r.reason))
         if 400 <= r.status_code < 500:
             try:

--- a/migrate.py
+++ b/migrate.py
@@ -355,10 +355,15 @@ def migrate_rooms(roomFile, config):
         _mxCreator = userLUT[channel["creator"]]
 
         _invitees = []
-        for user in channel["members"]:
-            if user != channel["creator"]:
-                if user in userLUT: # ignore dropped users like bots
-                    _invitees.append(userLUT[user])
+        if config_yaml["invite-all"]:
+            for user in nameLUT.keys():
+                if user != _mxCreator:
+                    _invitees.append(user)
+        else:
+            for user in channel["members"]:
+                if user != channel["creator"]:
+                    if user in userLUT: # ignore dropped users like bots
+                        _invitees.append(userLUT[user])
 
         roomDetails = {
             "slack_id": channel["id"],

--- a/migrate.py
+++ b/migrate.py
@@ -77,14 +77,10 @@ def test_config(yaml):
         print("No Application Service token defined in config")
         sys.exit(1)
 
-    if not config_yaml["slack_token"] and not yaml["skip-files"]:
-        print("No Slack acces token defined in config. Would not be able to migrate files.")
-        sys.exit(1)
-
     dry_run = config_yaml["dry-run"]
     skip_archived = config_yaml["skip-archived"]
 
-    config = { "zipfile": config_yaml["zipfile"], "dry-run": dry_run, "homeserver": config_yaml["homeserver"], "skip-archived": skip_archived, "as_token": config_yaml["as_token"], "slack_token": config_yaml["slack_token"], "skip-files": config_yaml["skip-files"]}
+    config = { "zipfile": config_yaml["zipfile"], "dry-run": dry_run, "homeserver": config_yaml["homeserver"], "skip-archived": skip_archived, "as_token": config_yaml["as_token"], "skip-files": config_yaml["skip-files"]}
 
     return config
 

--- a/migrate.py
+++ b/migrate.py
@@ -207,18 +207,18 @@ def register_user(
     user_type=None,
 ):
 
-    url = "%s/_synapse/admin/v1/users?access_token=%s" % (server_location,access_token,)
+    url = "%s/_synapse/admin/v2/users/@%s:%s" % (server_location, user, config_yaml['domain'])
+
+    headers = {'Authorization': ' '.join(['Bearer', access_token])}
 
     data = {
-        "username": user,
         "password": password,
         "displayname": displayname,
         "admin": admin,
-        "user_type": user_type,
     }
 
-    #_print("Sending registration request...")
-    r = requests.post(url, json=data, verify=False)
+    print("Creating user @%s:%s" % (user,config_yaml['domain']))
+    r = requests.put(url, json=data, headers=headers, verify=False)
 
     if r.status_code != 200:
         print("ERROR! Received %d %s" % (r.status_code, r.reason))
@@ -250,7 +250,7 @@ def register_room(
         "name": name,
         "topic": topic,
         "creation_content": {
-            "m.federate": False
+            "m.federate": True
         },
         "invite": invitees,
         "is_direct": is_dm,

--- a/migrate.py
+++ b/migrate.py
@@ -654,6 +654,7 @@ def parse_and_send_message(config, message, matrix_room, txnId, is_later):
     return txnId
 
 def migrate_messages(fileList, matrix_room, is_dm, config, tick):
+    global later
     archive = zipfile.ZipFile(config["zipfile"], 'r')
     txnId = 1
     progress = 0
@@ -674,6 +675,9 @@ def migrate_messages(fileList, matrix_room, is_dm, config, tick):
     # process postponed messages
     for message in later:
         txnId = parse_and_send_message(config, message, matrix_room, txnId, True)
+
+    # clean up postponed messages
+    later = []
 
 def main():
 
@@ -730,7 +734,7 @@ def main():
     print("Migrating messages to rooms. This may take a while...")
     for slack_room, matrix_room in roomLUT.items():
         print("Migrating messages for room: " + roomLUT2[slack_room])
-        fileList = loadZipFolder(config, roomLUT2[slack_room])
+        fileList = sorted(loadZipFolder(config, roomLUT2[slack_room]))
         if fileList:
             #print(fileList)
             tick = 1/len(fileList)

--- a/migrate.py
+++ b/migrate.py
@@ -577,7 +577,13 @@ def parse_and_send_message(config, message, matrix_room, txnId, is_later):
                     if "is_share" in attachment and attachment["is_share"]:
                         if body:
                             body += "\n"
-                        body += "".join(["&gt; _Shared (", attachment["footer"], "):_ ", attachment["text"], "\n"])
+                        attachment_footer = "no footer"
+                        if "footer" in attachment:
+                            attachment_footer = attachment["footer"]
+                        attachment_text = "no text"
+                        if "text" in attachment:
+                            attachment_text = attachment["text"]
+                        body += "".join(["&gt; _Shared (", attachment_footer, "):_ ", attachment_text, "\n"])
 
         if "replies" in message: # this is the parent of a thread
             is_thread = True

--- a/migrate.py
+++ b/migrate.py
@@ -245,7 +245,7 @@ def register_room(
         "name": name,
         "topic": topic,
         "creation_content": {
-            "m.federate": True
+            "m.federate": config_yaml["federate-rooms"]
         },
         "invite": invitees,
         "is_direct": is_dm,

--- a/migrate.py
+++ b/migrate.py
@@ -31,7 +31,7 @@ from emoji import emojize
 import slackdown
 import re
 from files import process_attachments, process_files
-from utils import send_event
+from utils import send_event, print
 
 
 channelTypes = ["dms.json", "groups.json", "mpims.json", "channels.json", "users.json"]

--- a/migrate.py
+++ b/migrate.py
@@ -703,7 +703,6 @@ def migrate_messages(fileList, matrix_room, is_dm, config, tick):
 
 def kick_imported_users(server_location, admin_user, access_token):
     headers = {'Authorization': ' '.join(['Bearer', access_token])}
-    #headers = {'Authorization': ' '.join(['Bearer', config_yaml["as_token"]])}
 
     for room in roomLUT.values():
         url = "%s/_matrix/client/r0/rooms/%s/kick" % (server_location, room)
@@ -756,7 +755,7 @@ def main():
 
     # create DMs
     if "dms.json" in jsonFiles and not dmLUT:
-        roomlist_dms = migrate_dms(jsonFiles["dms.json"], config)
+        roomlist_dms = migrate_dms(jsonFiles["dms.json"], config, admin_user)
 
     # write LUTs to file to be able to load from later if something goes wrong
     if not read_luts:
@@ -777,7 +776,6 @@ def main():
         print("Migrating messages for room: " + roomLUT2[slack_room])
         fileList = sorted(loadZipFolder(config, roomLUT2[slack_room]))
         if fileList:
-            #print(fileList)
             tick = 1/len(fileList)
             migrate_messages(fileList, matrix_room, False, config, tick)
 
@@ -787,15 +785,15 @@ def main():
     # send events to dms
     print("Migrating messages to DMs. This may take a while...")
     for slack_room, matrix_room in dmLUT.items():
-        fileList = loadZipFolder(config, slack_room)
+        fileList = sorted(loadZipFolder(config, slack_room))
         if fileList:
-            #print(fileList)
             tick = 1/len(fileList)
             migrate_messages(fileList, matrix_room, True, config, tick)
 
     # clean up postponed messages
     later = []
 
+    # kick imported users from non-dm rooms
     if config_yaml["kick-imported-users"]:
         kick_imported_users(config["homeserver"], admin_user, access_token)
 

--- a/migrate.py
+++ b/migrate.py
@@ -591,9 +591,16 @@ def parse_and_send_message(config, message, matrix_room, txnId, is_later):
 
         if "replies" in message: # this is the parent of a thread
             is_thread = True
+            previous_message = None
             for reply in message["replies"]:
                 if "user" in message and "ts" in message:
-                    replyLUT[reply["user"]+reply["ts"]] = message["user"]+message["ts"]
+                    first_message = message["user"]+message["ts"]
+                    current_message = reply["user"]+reply["ts"]
+                    if not previous_message:
+                        previous_message = first_message
+                    replyLUT[current_message] = previous_message
+                    if config_yaml["threads-reply-to-previous"]:
+                        previous_message = current_message
 
         # replys / threading
         if "thread_ts" in message and "parent_user_id" in message and not "replies" in message: # this message is a reply to another message

--- a/migrate.py
+++ b/migrate.py
@@ -213,7 +213,6 @@ def register_user(
         "admin": admin,
     }
 
-    print("Creating user @%s:%s" % (user,config_yaml['domain']))
     r = requests.put(url, json=data, headers=headers, verify=False)
 
     if r.status_code != 200 and r.status_code != 201:

--- a/migrate.py
+++ b/migrate.py
@@ -573,6 +573,11 @@ def parse_and_send_message(config, message, matrix_room, txnId, is_later):
         if "attachments" in message:
             if message["user"] in userLUT: # ignore attachments from bots
                 txnId = process_attachments(message["attachments"], matrix_room, userLUT[message["user"]], body, txnId, config)
+                for attachment in message["attachments"]:
+                    if "is_share" in attachment and attachment["is_share"]:
+                        if body:
+                            body += "\n"
+                        body += "".join(["&gt; _Shared (", attachment["footer"], "):_ ", attachment["text"], "\n"])
 
         if "replies" in message: # this is the parent of a thread
             is_thread = True

--- a/migrate.py
+++ b/migrate.py
@@ -103,7 +103,8 @@ def loadZipFolder(config, folder):
 
         fileList = []
         for entry in archive:
-            if folder in entry.filename and entry.is_dir() == False:
+            file_basename = entry.filename.split("/", maxsplit=1)[0]
+            if entry.is_dir() == False and folder == file_basename:
                 fileList.append(entry.filename)
 
         return fileList

--- a/required.txt
+++ b/required.txt
@@ -1,4 +1,4 @@
-PyYAML==5.1
-requests==2.21.0
-emoji>=0.5.4
-slackdown==0.0.3
+PyYAML
+requests
+emoji
+slackdown

--- a/required.txt
+++ b/required.txt
@@ -1,4 +1,4 @@
 PyYAML==5.1
 requests==2.21.0
-pyemojify==0.2.0
+emoji>=0.5.4
 slackdown==0.0.3

--- a/utils.py
+++ b/utils.py
@@ -14,6 +14,25 @@
 # limitations under the License.
 
 import requests
+import functools
+
+def super_print(filename):
+    '''filename is the file where output will be written'''
+    def wrap(func):
+        '''func is the function you are "overriding", i.e. wrapping'''
+        def wrapped_func(*args,**kwargs):
+            '''*args and **kwargs are the arguments supplied
+            to the overridden function'''
+            #use with statement to open, write to, and close the file safely
+            with open(filename,'a') as outputfile:
+                outputfile.write(*args,**kwargs)
+                outputfile.write("\n")
+            #now original function executed with its arguments as normal
+            return func(*args,**kwargs)
+        return wrapped_func
+    return wrap
+
+print = super_print('migration.log')(print)
 
 def send_event(
     config,

--- a/utils.py
+++ b/utils.py
@@ -37,8 +37,8 @@ def send_event(
         print("ERROR! Received %d %s" % (r.status_code, r.reason))
         if 400 <= r.status_code < 500:
             try:
-                print(r.json()["error"])
-                print(matrix_message)
+                print(' '.join([r.status_code, r.json()["error"]]))
+                #print(matrix_message)
             except Exception:
                 pass
         return False


### PR DESCRIPTION
This PR makes it compatible with recent [Synapse](https://github.com/matrix-org/synapse) versions and adds new config options allowing to effectively import a Slack workspace history to an existing Homeserver via federation.

### New features

- Handle shared messages as quotes
- Add option to enable room federation
- Add option to add suffix to names and create rooms as admin
- Add option to kick all imported users
- Add option to reply to previous message in thread (default config changed)
- Add option to import public channels as private rooms
- If snippets are too large, send as file
- Add logging to file
- Write links to log for files that are too large and sent as link

### Bugfixes

- Fixes #1 (compatible with [Synapse v1.17.0](https://github.com/matrix-org/synapse/releases/tag/v1.17.0), tested using free Slack exports only and the federated setup)
- Fixes #2
- Probably fixes #3
- Fix missing code in formatted_content for snippets
- Fix emoji migration
- Add `invite-all` option as workaround for `user not in room`
- Fix message ordering (sort json files from slack_export.zip)
- Fix file timestamps
- Fix importing messages from other channels
- Fix duplicated messages for image captions 