### PR TITLE
Hoist config variable to top scope

### DIFF
--- a/slack-matrix-migration/slack-matrix-migration/migrate.py
+++ b/slack-matrix-migration/slack-matrix-migration/migrate.py
@@ -107,6 +107,8 @@ def test_config(yaml):
 
     return config
 
+config = test_config(config_yaml)
+
 def loadZip(config):
     zipName = config["zipfile"]
     log.info("Opening zipfile: " + zipName)
@@ -865,8 +867,6 @@ def kick_imported_users(server_location, admin_user, access_token, tick):
 def main():
     logging.captureWarnings(True)
     log = logging.getLogger('SLACK.MIGRATE.MAIN')
-
-    config = test_config(yaml)
 
     jsonFiles = loadZip(config)
 


### PR DESCRIPTION
It seems that in recent changes the config was moved into the main function, but not passed to all necessary other functions as an argument. To fix it for my case I simply put the config in the global scope.

This should also help fix #10 